### PR TITLE
fix(events): fix keyboard/mouse events in another window

### DIFF
--- a/src/view/actions/context-menu/context-menu.ts
+++ b/src/view/actions/context-menu/context-menu.ts
@@ -9,10 +9,10 @@ import { showViewContextMenu } from 'src/view/actions/context-menu/view-context-
 export const contextMenu = (element: HTMLElement, view: LineageView) => {
     const listener = (e: MouseEvent | TouchEvent) => {
         if (cardContextMenuPredicate(e)) {
-            if (e instanceof MouseEvent) showCardContextMenu(e, view);
+            if (e.instanceOf(MouseEvent)) showCardContextMenu(e, view);
             else showCardContextMenu(new MouseEvent('contextmenu', e), view);
         } else if (viewContextMenuPredicate(e)) {
-            if (e instanceof MouseEvent) showViewContextMenu(e, view);
+            if (e.instanceOf(MouseEvent)) showViewContextMenu(e, view);
             else showViewContextMenu(new MouseEvent('contextmenu', e), view);
         }
     };

--- a/src/view/actions/keyboard-shortcuts/keyboard-shortcuts.ts
+++ b/src/view/actions/keyboard-shortcuts/keyboard-shortcuts.ts
@@ -31,8 +31,8 @@ export const keyboardShortcuts = (
                 updateCommandsDictionary(state.hotkeys);
         },
     );
-    const keyboardEventHandler = (event: Event) => {
-        if (!(event instanceof KeyboardEvent)) return;
+    const keyboardEventHandler = (event: UIEvent) => {
+        if (!(event.instanceOf(KeyboardEvent))) return;
         if (event.key === 'Escape') {
             const contain = handleEscapeKey(view);
             if (contain) return;


### PR DESCRIPTION
When a note is open in a separate window, instanceof checks fail for types like MouseEvent, KeyboardEvent, etc. With this fix, they work as explected.

- In keyboard-shortcuts.ts although addEventListener requires a callback with a param of type Event, it is the derived UIEvent that defines the .instanceOf method. I'm not sure if changing the param type to UIEvent is the proper fix, but it prevents compile errors.

- In droppable.ts there are two instanceof HTMLElement checks, but surprisingly they work as expected in other windows without any changes. Also the used EventTarget type has no .instanceOf method, so I left them be.

- There are a few uses of the window and document globals throughout the codebase, which may or my not need to be replaced by activeWindow and activeDocument - I haven't tested any of them and I don't' know if they work as expected in other windows

fixes #40 

The fix is made to comply with the referenced ObsidianMD blog post.

REF: [How to update your plugin to support pop-out windows] (https://obsidian.md/blog/how-to-update-plugins-to-support-pop-out-windows/)